### PR TITLE
Use Array.prototype.push instead of array.push

### DIFF
--- a/src/BrAPINode.js
+++ b/src/BrAPINode.js
@@ -115,7 +115,7 @@ class BrAPINode extends ThreadNode {
                         return Promise.all(further_pages).then(function(furtherResults){
                             initialResult.metadata.currentPage = [initialResult.metadata.currentPage];
                             furtherResults.forEach(function(furtherResponse){
-                                Array.push.apply(
+                                Array.prototype.push.apply(
                                     initialResult.result.data,
                                     furtherResponse.result.data
                                 );


### PR DESCRIPTION
I was getting Array.push undefined in Chrome, it seems in Firefox [Array.push == Array.prototype.push](https://stackoverflow.com/questions/15444242/why-doesnt-array-push-apply-work#comment23695480_15444261) but not in Chrome