### PR TITLE
Initialize result to object when it's empty

### DIFF
--- a/src/BrAPINode.js
+++ b/src/BrAPINode.js
@@ -283,7 +283,7 @@ class BrAPICallController {
     
     static parseBrAPIResponse(resp){
         var brapiInfo = {
-            result: resp.result,
+            result: resp.result || {},
             metadata:resp.metadata
         };
         // console.log(resp);


### PR DESCRIPTION
This might happen for example in a PUT call with an empty result:
```
{
   metadata: { ... }
   result: ""
}
```

cc @MFlores2021 @lukasmueller  