### PR TITLE
Normalize "patch" http method to uppercase

### DIFF
--- a/src/BrAPINode.js
+++ b/src/BrAPINode.js
@@ -247,6 +247,10 @@ class BrAPICallController {
         else{
             url = url+BrAPICallController.formatURLParams(params)
         }
+        if (method == "patch") {
+            // fetch spec doesn't normalize patch so we do it here
+            method = "PATCH";
+        }
         var fetch_opts = {
             method: method,
             cache: "no-cache",


### PR DESCRIPTION
The `fetch` spec doesn't normalize `patch` :
- https://fetch.spec.whatwg.org/#concept-method-normalize
- `https://github.com/whatwg/fetch/issues/50`

This means that fetch will send `post` as `POST` (same with get, put, etc) but not in the case of patch, which is send _as is_, and most of the servers expect the uppercase version.

@MFlores2021 @dauglyon 