### PR TITLE
Allow to send token over http?

### DIFF
--- a/src/BrAPINode.js
+++ b/src/BrAPINode.js
@@ -257,6 +257,9 @@ class BrAPICallController {
             body: body
         };
         if (this.brapi_auth_token) {
+            if (!this.brapi_base_url.startsWith("https")) {
+                console.warn("You should send the BrAPI.js authentication token over https!")
+            }
             console.log("auth", this.brapi_auth_token);
             fetch_opts.headers.Authorization = "Bearer " + this.brapi_auth_token;
         }

--- a/src/BrAPINode.js
+++ b/src/BrAPINode.js
@@ -256,13 +256,9 @@ class BrAPICallController {
             },
             body: body
         };
-        if(this.brapi_auth_token){
-            if(this.brapi_base_url.startsWith("https")){
-                console.log("auth",this.brapi_auth_token);
-                fetch_opts.headers.Authorization = "Bearer "+this.brapi_auth_token;
-            } else {
-                console.warn("BrAPI.js will only send authentication token over https!")
-            }
+        if (this.brapi_auth_token) {
+            console.log("auth", this.brapi_auth_token);
+            fetch_opts.headers.Authorization = "Bearer " + this.brapi_auth_token;
         }
         // console.log("fetch(",url,",",fetch_opts,")")
         var self = this;


### PR DESCRIPTION
I'm not sure about this one, but some clients may want to use the token while working in a local environment, and most the times https is not available at that point. 

Is there any alternative? Is it ok to let the client secure their api and don't make any assumption?

For discussion.

@MFlores2021 @BrapiCoordinatorSelby @dauglyon 