### PR TITLE
Adding credentials configuration option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,11 +20,9 @@ BrAPI.js supports BrAPI versions `v1.0`-`v2.0`. Currently, it expects a server t
 ```bash
 # Be sure your version of NPM supports 'prepare' scripts (>=npm@4.0.0)
 # Recommended:
-npm install @solgenomics/brapijs 
+npm install git+https://github.com/solgenomics/BrAPI-js
 # Otherwise:
-npm install git+https://github.com/solgenomics/BrAPI.js.git
-# or:
-git clone https://github.com/solgenomics/BrAPI.js.git
+git clone https://github.com/solgenomics/BrAPI-js.git
 cd BrAPI.js
 npm install . 
 ```
@@ -52,10 +50,11 @@ BrAPI.js has been designed to allow for many simultaneous and interdependent cal
 
 ### Initialization and Configuration
 
-<a name="root" href="#root">#</a> **BrAPI**(_address_, [_version_, _auth_token_, _call_limit_]) [<>](main.js "Source")  
+<a name="root" href="#root">#</a> **BrAPI**(_address_, [_version_, _auth_token_, _call_limit_, _credentials_]) [<>](main.js "Source")  
 
 Creates a root _BrAPINode_. This is the root of a BrAPI.js [DAG dataflow](#how-it-works). The _address_ should be a string with the base URL of a BrAPI instance that is being queried, i.e. "https://www.yambase.org/brapi/v1". If an _auth_token_ is provided, it will be added as a Bearer header when sending requests over HTTPS. Changing the _version_ determines which deprecation/removal warnings are written the console, it does not restrict functionality.
 The _call_limit_ parameter specifies how many simultaneous requests may be run by this node and its descendants against the specified server.
+The _credentials_ parameter allows you to define how HTTP credentials (aka cookies) should be included in a request.  See https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials for more information.
 
 ###### Examples:
 
@@ -89,7 +88,7 @@ var brapi_root1 = BrAPI("https://www.myserver.org/brapi/v1","v1.2") // for your 
     .each(...);
 ```
 
-<a name="server" href="#server">#</a> _node_.**server**(_address_, [_version_, _auth_token_, _call_limit_]) [<>](src/BrAPINodes.js "Source")  
+<a name="server" href="#server">#</a> _node_.**server**(_address_, [_version_, _auth_token_, _call_limit_, _credentials_]) [<>](src/BrAPINodes.js "Source")  
 
 Creates and returns a child _BrAPINode_ which changes the BrAPI server instance queried by all descendants.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solgenomics/brapijs",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "BrAPI.js is a JavaScript client library for [BrAPI](https://brapi.org). It can be used either in the browser or within Node.js. It uses the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (or [node-fetch]() in Node.js) for AJAX calls. BrAPI.js also uses ES6 classes.",
   "bugs": {
     "url": "https://github.com/solgenomics/BrAPI.js/issues"

--- a/src/BrAPINode.js
+++ b/src/BrAPINode.js
@@ -209,13 +209,14 @@ class EmptyBrAPINode extends BrAPINode{
 EmptyBrAPINode.prototype.data = EmptyThreadNode.prototype.data;
 
 class BrAPICallController {
-    constructor(brapi_base_url,version,brapi_auth_token,max_calls){
+    constructor(brapi_base_url,version,brapi_auth_token,max_calls,credentials){
         this.max_calls = max_calls || 5;
         this.call_queue = [];
         this.version = brapiVersion(version||1.2);
         this.running = 0;
         this.brapi_base_url = brapi_base_url;
         this.brapi_auth_token = brapi_auth_token;
+        this.credentials = credentials || 'same-origin';
     }
     call(){
         var self = this;
@@ -250,7 +251,7 @@ class BrAPICallController {
         var fetch_opts = {
             method: method,
             cache: "no-cache",
-            credentials: "same-origin",
+            credentials: this.credentials,
             headers: {
                 'Content-Type': 'application/json;charset=utf-8'
             },
@@ -397,11 +398,12 @@ Object.keys(brapiMethods).forEach(function(method_name){
  * @param   {String} version     Optional. BrAPI version of endpoint (e.g. "1.2" or "v1.1") 
  * @param   {String} auth_token  Optional. BrAPI Auth Bearer token.
  * @param   {Int}    call_limit  Optional. Maximum number of simultanious calls the server which can be running.
+ * @param   {String} credentials Optional. credentials option to use for fetch API.  See: https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
  * @returns {EmptyBrAPINode}            
  */ 
-export function BrAPI(address, version, auth_token, call_limit){
+export function BrAPI(address, version, auth_token, call_limit, credentials){
     return new EmptyBrAPINode(
-        new BrAPICallController(address,version,auth_token,call_limit||5)
+        new BrAPICallController(address,version,auth_token,call_limit||5, credentials)
     );
 }
 


### PR DESCRIPTION
Allow a client of the BrAPI-js library to configure how credentials should be sent to the server.  Options are defined here: https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials